### PR TITLE
12 need to execute kubectl commands from local to harvester running on nested vms

### DIFF
--- a/modules/harvester/harvester_startup_script_sh.tpl
+++ b/modules/harvester/harvester_startup_script_sh.tpl
@@ -30,8 +30,6 @@ for i in $(seq 1 ${count}); do
 done
 
 # Monitoring VM states and restarting them when all are 'shut off'
-#(sudo crontab -l 2>/dev/null; echo "*/5 * * * * virsh list --all | awk 'NR>2 && \$3 == \"shut\" {print \$2}' | xargs -r -I{} virsh start {}") | sudo crontab -
-
 sudo chmod +x  /usr/local/bin/restart_harvester_vms_script.sh
 (sudo crontab -l 2>/dev/null; echo "*/2 * * * * /usr/local/bin/restart_harvester_vms_script.sh") | sudo crontab -
 
@@ -39,3 +37,6 @@ sudo chmod +x  /usr/local/bin/restart_harvester_vms_script.sh
 sudo chmod 755 /etc/systemd/system/socat-proxy.service
 sudo systemctl daemon-reload
 sudo systemctl enable --now socat-proxy.service
+
+# Copying the KUBECONFIG file from the RKE2 cluster under the hood of Harvester
+sudo sshpass -p "${password}" ssh -oStrictHostKeyChecking=no "rancher@192.168.122.120" "sudo cat /etc/rancher/rke2/rke2.yaml" > /tmp/rke2.yaml

--- a/modules/harvester/harvester_startup_script_sh.tpl
+++ b/modules/harvester/harvester_startup_script_sh.tpl
@@ -41,7 +41,7 @@ sudo systemctl enable --now socat-proxy.service
 # Wait for the Harvester services to start
 attempts=0
 while [ "$attempts" -lt 15 ]; do
-  resp=$(curl -k -s -o /dev/null -w "%{{http_code}}" https://$(curl -s http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip -H "Metadata-Flavor: Google")/ping)
+  resp=$(curl -k -s -o /dev/null -w "{{http_code}}" https://$(curl -s http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip -H "Metadata-Flavor: Google")/ping)
   echo 'Waiting for https://$(curl -s http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip -H "Metadata-Flavor: Google")/ping - response: $resp'
   if [ "$resp" = "200" ]; then
     ((attempts++))

--- a/modules/harvester/harvester_startup_script_sh.tpl
+++ b/modules/harvester/harvester_startup_script_sh.tpl
@@ -54,3 +54,4 @@ done
 
 # Copying the KUBECONFIG file from the RKE2 cluster under the hood of Harvester
 sudo sshpass -p "${password}" ssh -oStrictHostKeyChecking=no "rancher@192.168.122.120" "sudo cat /etc/rancher/rke2/rke2.yaml" > /tmp/rke2.yaml
+sudo sed -i "/certificate-authority-data:/c\\    insecure-skip-tls-verify: true" /tmp/rke2.yaml

--- a/modules/harvester/harvester_startup_script_sh.tpl
+++ b/modules/harvester/harvester_startup_script_sh.tpl
@@ -41,7 +41,7 @@ sudo systemctl enable --now socat-proxy.service
 # Wait for the Harvester services to start
 attempts=0
 while [ "$attempts" -lt 15 ]; do
-  resp=$(curl -k -s -o /dev/null -w "{{http_code}}" https://$(curl -s http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip -H "Metadata-Flavor: Google")/ping)
+  resp=$(wget --server-response --spider https://$(curl -s http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip -H "Metadata-Flavor: Google")/ping 2>&1 | grep "HTTP/" | awk '{print $2}')
   echo 'Waiting for https://$(curl -s http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip -H "Metadata-Flavor: Google")/ping - response: $resp'
   if [ "$resp" = "200" ]; then
     ((attempts++))

--- a/modules/harvester/harvester_startup_script_sh.tpl
+++ b/modules/harvester/harvester_startup_script_sh.tpl
@@ -43,11 +43,11 @@ attempts=0
 while [ "$attempts" -lt 15 ]; do
   ip=$(curl -s http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip -H "Metadata-Flavor: Google")
   response=$(curl -k -s "https://$ip/ping")
-  echo "Waiting for https://$ip/ping - response: $response"
   if [ "$response" == "pong" ]; then
+    echo "Waiting for https://$ip/ping - response: $response"
     ((attempts++))
   else
-    echo "Response is not 'pong', retrying in 2 seconds..."
+    echo "Waiting for https://$ip/ping - response is not 'pong', retrying in 2 seconds..."
   fi
   sleep 2
 done

--- a/modules/harvester/harvester_startup_script_sh.tpl
+++ b/modules/harvester/harvester_startup_script_sh.tpl
@@ -44,12 +44,17 @@ while [ "$attempts" -lt 15 ]; do
   ip=$(curl -s http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip -H "Metadata-Flavor: Google")
   response=$(curl -i -s "https://$ip/ping")
   http_code=$(echo "$response" | grep HTTP | awk '{print $2}')
-  if [ "$http_code" -eq 200 ]; then
-    echo "Waiting for https://$ip/ping - response: $http_code"
-    ((attempts++))
+  if [ -n "$http_code" ]; then
+    # Confronta se il codice di stato è 200
+    if [ "$http_code" -eq 200 ]; then
+      echo "Waiting for https://$ip/ping - response: $http_code"
+      ((attempts++))
+    else
+      echo "Waiting for https://$ip/ping - response: $http_code (retrying)"
+    fi
   else
-    echo "Waiting for https://$ip/ping - response: $http_code (retrying)"
-  fi  
+    echo "No HTTP response received from https://$ip/ping (retrying)"
+  fi
   sleep 2
 done
 

--- a/modules/harvester/harvester_startup_script_sh.tpl
+++ b/modules/harvester/harvester_startup_script_sh.tpl
@@ -41,7 +41,7 @@ sudo systemctl enable --now socat-proxy.service
 # Wait for the Harvester services to start
 attempts=0
 while [ "$attempts" -lt 15 ]; do
-  resp=$(curl -k -s -o /dev/null -w "\\%{http_code}" https://$(curl -s http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip -H "Metadata-Flavor: Google")/ping)
+  resp=$(curl -k -s -o /dev/null -w "%{{http_code}}" https://$(curl -s http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip -H "Metadata-Flavor: Google")/ping)
   echo 'Waiting for https://$(curl -s http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip -H "Metadata-Flavor: Google")/ping - response: $resp'
   if [ "$resp" = "200" ]; then
     ((attempts++))

--- a/modules/harvester/harvester_startup_script_sh.tpl
+++ b/modules/harvester/harvester_startup_script_sh.tpl
@@ -42,18 +42,12 @@ sudo systemctl enable --now socat-proxy.service
 attempts=0
 while [ "$attempts" -lt 15 ]; do
   ip=$(curl -s http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip -H "Metadata-Flavor: Google")
-  response=$(curl -i -s "https://$ip/ping")
-  http_code=$(echo "$response" | grep HTTP | awk '{print $2}')
-  if [ -n "$http_code" ]; then
-    # Confronta se il codice di stato è 200
-    if [ "$http_code" -eq 200 ]; then
-      echo "Waiting for https://$ip/ping - response: $http_code"
-      ((attempts++))
-    else
-      echo "Waiting for https://$ip/ping - response: $http_code (retrying)"
-    fi
+  response=$(curl -k -s "https://$ip/ping")
+  echo "Waiting for https://$ip/ping - response: $response"
+  if [ "$response" == "pong" ]; then
+    ((attempts++))
   else
-    echo "No HTTP response received from https://$ip/ping (retrying)"
+    echo "Response is not 'pong', retrying in 2 seconds..."
   fi
   sleep 2
 done

--- a/modules/harvester/sles_startup_script_sh.tpl
+++ b/modules/harvester/sles_startup_script_sh.tpl
@@ -26,7 +26,6 @@ sudo curl -L -o /srv/www/harvester/harvester-${version}-amd64.iso \
   https://releases.rancher.com/harvester/${version}/harvester-${version}-amd64.iso && \
   touch /tmp/harvester_download_done
 
-
 # Disk partitioning
 for i in $(seq 1 "${count}"); do
   if [ -b "${disk_name}$(printf "\x$(printf %x $((97 + i)))")" ]; then

--- a/modules/harvester/sles_startup_script_sh.tpl
+++ b/modules/harvester/sles_startup_script_sh.tpl
@@ -13,7 +13,7 @@ sudo curl -L -o /etc/nginx/nginx.conf \
 sudo curl -L -o /srv/www/harvester/vlan1.xml \
   https://raw.githubusercontent.com/glovecchi0/harvester-gcp-tf/refs/heads/main/modules/harvester/qemu_vlan1_xml.tpl
 sudo curl -L -o /etc/systemd/system/socat-proxy.service \
-  https://raw.githubusercontent.com/glovecchi0/harvester-gcp-tf/refs/heads/12-need-to-execute-kubectl-commands-from-local-to-harvester-running-on-nested-vms/modules/harvester/socat_proxy_service.tpl
+  https://raw.githubusercontent.com/glovecchi0/harvester-gcp-tf/refs/heads/main/modules/harvester/socat_proxy_service.tpl
 sudo curl -L -o /usr/local/bin/restart_harvester_vms_script.sh \
   https://raw.githubusercontent.com/glovecchi0/harvester-gcp-tf/refs/heads/main/modules/harvester/restart_harvester_vms_script_sh.tpl
 sudo curl -L -o /srv/www/harvester/harvester-${version}-vmlinuz-amd64 \

--- a/modules/harvester/sles_startup_script_sh.tpl
+++ b/modules/harvester/sles_startup_script_sh.tpl
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 # Installation of pre-requisite packages
-sudo zypper --non-interactive install parted util-linux virt-install libvirt qemu-kvm python3-websockify novnc socat nginx
+sudo zypper --non-interactive addrepo https://download.opensuse.org/repositories/network/SLE_15/network.repo
+sudo zypper --non-interactive --gpg-auto-import-keys refresh
+sudo zypper --non-interactive install parted util-linux virt-install libvirt qemu-kvm python3-websockify novnc socat nginx sshpass
 sudo systemctl enable --now libvirtd
 sudo mkdir -p /srv/www/harvester
 
@@ -11,7 +13,7 @@ sudo curl -L -o /etc/nginx/nginx.conf \
 sudo curl -L -o /srv/www/harvester/vlan1.xml \
   https://raw.githubusercontent.com/glovecchi0/harvester-gcp-tf/refs/heads/main/modules/harvester/qemu_vlan1_xml.tpl
 sudo curl -L -o /etc/systemd/system/socat-proxy.service \
-  https://raw.githubusercontent.com/glovecchi0/harvester-gcp-tf/refs/heads/main/modules/harvester/socat_proxy_service.tpl
+  https://raw.githubusercontent.com/glovecchi0/harvester-gcp-tf/refs/heads/12-need-to-execute-kubectl-commands-from-local-to-harvester-running-on-nested-vms/modules/harvester/socat_proxy_service.tpl
 sudo curl -L -o /usr/local/bin/restart_harvester_vms_script.sh \
   https://raw.githubusercontent.com/glovecchi0/harvester-gcp-tf/refs/heads/main/modules/harvester/restart_harvester_vms_script_sh.tpl
 sudo curl -L -o /srv/www/harvester/harvester-${version}-vmlinuz-amd64 \

--- a/modules/harvester/socat_proxy_service.tpl
+++ b/modules/harvester/socat_proxy_service.tpl
@@ -2,8 +2,7 @@
 Description=Socat Service
 
 [Service]
-ExecStart=/usr/bin/socat TCP-LISTEN:443,fork TCP:192.168.122.120:443
-ExecStart=/usr/bin/socat TCP-LISTEN:6443,fork TCP:192.168.122.120:6443
+ExecStart=/bin/bash -c "/usr/bin/socat TCP-LISTEN:443,fork TCP:192.168.122.120:443 & /usr/bin/socat TCP-LISTEN:6443,fork TCP:192.168.122.120:6443 & wait"
 Restart=always
 User=root
 

--- a/modules/harvester/socat_proxy_service.tpl
+++ b/modules/harvester/socat_proxy_service.tpl
@@ -3,6 +3,7 @@ Description=Socat Service
 
 [Service]
 ExecStart=/usr/bin/socat TCP-LISTEN:443,fork TCP:192.168.122.120:443
+ExecStart=/usr/bin/socat TCP-LISTEN:6443,fork TCP:192.168.122.120:6443
 Restart=always
 User=root
 

--- a/projects/google-cloud/docs.md
+++ b/projects/google-cloud/docs.md
@@ -13,6 +13,7 @@
 |------|---------|
 | <a name="provider_local"></a> [local](#provider\_local) | n/a |
 | <a name="provider_null"></a> [null](#provider\_null) | n/a |
+| <a name="provider_ssh"></a> [ssh](#provider\_ssh) | 2.6.0 |
 
 ## Modules
 
@@ -28,11 +29,13 @@
 | [local_file.default_ipxe_script_config](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_file.harvester_startup_script](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_file.join_cloud_config_yaml](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
+| [local_file.kube_config_yaml](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_file.sles_startup_script_config](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [null_resource.copy_files_to_first_node](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.harvester_iso_download_checking](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.harvester_node_startup](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.wait_harvester_services_startup](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [ssh_resource.retrieve_kubeconfig](https://registry.terraform.io/providers/loafoe/ssh/2.6.0/docs/resources/resource) | resource |
 | [local_file.sles_startup_script](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |
 | [local_file.ssh_private_key](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |
 

--- a/projects/google-cloud/docs.md
+++ b/projects/google-cloud/docs.md
@@ -34,7 +34,6 @@
 | [null_resource.copy_files_to_first_node](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.harvester_iso_download_checking](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.harvester_node_startup](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [null_resource.wait_harvester_services_startup](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [ssh_resource.retrieve_kubeconfig](https://registry.terraform.io/providers/loafoe/ssh/2.6.0/docs/resources/resource) | resource |
 | [local_file.sles_startup_script](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |
 | [local_file.ssh_private_key](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |

--- a/projects/google-cloud/main.tf
+++ b/projects/google-cloud/main.tf
@@ -207,3 +207,13 @@ resource "null_resource" "kubeconfig_file" {
     }
   }
 }
+
+resource "null_resource" "kubeconfig_scp" {
+  depends_on = [null_resource.kubeconfig_file]
+  provisioner "local-exec" {
+    command     = <<-EOF
+      scp -i ${var.ssh_private_key_path} -o -oStrictHostKeyChecking=no ${local.ssh_username}@${module.harvester_node.instances_public_ip[0]}:/tmp/rke2.yaml ${path.cwd}/${var.prefix}-kubeconfig.yaml
+      EOF
+    interpreter = ["/bin/bash", "-c"]
+  }
+}

--- a/projects/google-cloud/main.tf
+++ b/projects/google-cloud/main.tf
@@ -212,7 +212,7 @@ resource "null_resource" "kubeconfig_scp" {
   depends_on = [null_resource.kubeconfig_file]
   provisioner "local-exec" {
     command     = <<-EOF
-      scp -i ${var.ssh_private_key_path} -o -oStrictHostKeyChecking=no ${local.ssh_username}@${module.harvester_node.instances_public_ip[0]}:/tmp/rke2.yaml ${path.cwd}/${var.prefix}-kubeconfig.yaml
+      scp -i ${local.ssh_private_key_path} -o StrictHostKeyChecking=no ${local.ssh_username}@${module.harvester_node.instances_public_ip[0]}:/tmp/rke2.yaml ${path.cwd}/${var.prefix}-kubeconfig.yaml
       EOF
     interpreter = ["/bin/bash", "-c"]
   }


### PR DESCRIPTION
We need to change this back to main once its tested and approved by @glovecchi0 
 
from: 

`sudo curl -L -o /etc/systemd/system/socat-proxy.service \
  https://raw.githubusercontent.com/glovecchi0/harvester-gcp-tf/refs/heads/12-need-to-execute-kubectl-commands-from-local-to-harvester-running-on-nested-vms/modules/harvester/socat_proxy_service.tpl`

to:

`sudo curl -L -o /etc/systemd/system/socat-proxy.service \
  https://raw.githubusercontent.com/glovecchi0/harvester-gcp-tf/refs/heads/main/modules/harvester/socat_proxy_service.tpl`